### PR TITLE
Dependencies added for Spiderfoot

### DIFF
--- a/modules/intelligence-gathering/spiderfoot.py
+++ b/modules/intelligence-gathering/spiderfoot.py
@@ -20,7 +20,10 @@ REPOSITORY_LOCATION="https://github.com/smicallef/spiderfoot.git"
 INSTALL_LOCATION="spiderfoot"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN=""
+DEBIAN="libxslt1-dev,libxml2-dev"
+
+# DEPENDS FOR FEDORA INSTALLS
+FEDORA="libxslt1-devel,libxml2-devel"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="pip install lxml netaddr M2Crypto cherrypy mako"


### PR DESCRIPTION
Compile issues with no dependencies. Issues solved by ensuring development packages for libxslt1 and libxml2